### PR TITLE
Update promethues-rabbitmq-deploy.yaml

### DIFF
--- a/Kubernetes/k8s-rabbitmq-exporter/promethues-rabbitmq-deploy.yaml
+++ b/Kubernetes/k8s-rabbitmq-exporter/promethues-rabbitmq-deploy.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
   selector:
     app: rabbitmq
-spec:
   type: NodePort
   ports:
     - name: rabbitmq


### PR DESCRIPTION
两个spec导致service的selector为空，即无法匹配到pod